### PR TITLE
fix typo on usage example in comment

### DIFF
--- a/typedraft.config.ts
+++ b/typedraft.config.ts
@@ -5,7 +5,7 @@ import { IDSL, ToString, ToAst } from "typedraft";
  * convert
  * 
  * {
- *   "use match",
+ *   "use match";
  *   ["a","b","c"].map(value => {...})
  * }
  * 


### PR DESCRIPTION
when using DSL declarative, it should be two valid typescript statements, separated by semicolon, not comma.
Otherwise tsc (IDE hint) will raise an error `TS2695: Left side of comma operator is unused and has no side effects.`